### PR TITLE
Refresh properties window when reload is clicked

### DIFF
--- a/src/obs-shaderfilter.c
+++ b/src/obs-shaderfilter.c
@@ -311,7 +311,7 @@ static bool shader_filter_reload_effect_clicked(obs_properties_t *props, obs_pro
 
 	obs_source_update(filter->context, NULL);
 
-	return false;
+	return true;
 }
 
 static const char *shader_filter_texture_file_filter =


### PR DESCRIPTION
Callbacks from properties window use their return value to indicate that the property window needs to be redrawn/refreshed. Hence return true should be used.